### PR TITLE
Replace depreciated .live method in jQuery 1.9

### DIFF
--- a/fluent_comments/static/fluent_comments/js/ajaxcomments.js
+++ b/fluent_comments/static/fluent_comments/js/ajaxcomments.js
@@ -21,7 +21,7 @@
 
 
         // Bind events for threaded comment reply
-        $('.comment-reply-link').live('click', showThreadedReplyForm);
+        $('.comment-reply-link').on('click', showThreadedReplyForm);
         $('.comment-cancel-reply-link').click(cancelThreadedReplyForm);
         $('.js-comments-form').wrap('<div class="js-comments-form-orig-position"></div>');
 


### PR DESCRIPTION
`.live` was depreciated in jQuery 1.7 and removed in 1.9 (see: http://api.jquery.com/live/).
