### PR TITLE
custom comment model with manager for less sqlqueries

### DIFF
--- a/fluent_comments/__init__.py
+++ b/fluent_comments/__init__.py
@@ -1,8 +1,8 @@
 """
 API for :ref:`custom-comment-app-api`
 """
-from django.contrib.comments import Comment
 from fluent_comments import appsettings
+from fluent_comments.models import LightComment
 from fluent_comments.forms import FluentCommentForm
 
 
@@ -23,7 +23,7 @@ def get_model():
     if appsettings.USE_THREADEDCOMMENTS:
         return ThreadedComment
     else:
-        return Comment
+        return LightComment
 
 
 def get_form():

--- a/fluent_comments/models.py
+++ b/fluent_comments/models.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 from django.contrib import comments
+from django.contrib.comments import Comment
+from django.contrib.comments.managers import CommentManager
 from django.contrib.contenttypes.generic import GenericRelation
 from django.contrib.sites.models import get_current_site
 from django.core.mail import send_mail
@@ -9,6 +11,14 @@ from django.template import RequestContext
 from django.template.loader import render_to_string
 from fluent_comments import appsettings
 
+class LightCommentManager(CommentManager):
+    def get_query_set(self):
+        return (super(CommentManager, self).get_query_set().select_related('user'))
+
+class LightComment(Comment):
+    objects = LightCommentManager()
+    class Meta:
+        proxy = True
 
 @receiver(signals.comment_was_posted)
 def on_comment_posted(sender, comment, request, **kwargs):


### PR DESCRIPTION
Hi,

I really like this package and wondered how you feel about this proposal.  

Currently, every comment from an authenticated user generates an sql query (as noted here: http://stackoverflow.com/questions/7887141/how-to-make-django-comments-use-select-related-on-user-field)

This proposal seeks to reduce queries by building the comment list with a select_related.

Alternatively, it might be better to define a plugin comment model and users can solve this as they please?
