### PR TITLE
enable apps to extend comment.html and form.html

### DIFF
--- a/fluent_comments/templates/comments/comment.html
+++ b/fluent_comments/templates/comments/comment.html
@@ -18,6 +18,7 @@
 {% endcomment %}
 {% load i18n %}
         <div{% if preview %} id="comment-preview"{% else %} id="c{{ comment.id }}"{% endif %} class="comment-item">
+        {% block fluent_comment %}
           {% if preview %}<h3>{% trans "Preview of your comment" %}</h3>{% endif %}
             <h4>
               {% if comment.url %}<a href="{{ comment.url }}" rel="nofollow">{% endif %}
@@ -26,7 +27,8 @@
               <span class="comment-date">{% blocktrans with submit_date=comment.submit_date %}on {{ submit_date }}{% endblocktrans %}</span>
               {% if not comment.is_public %}<span class="comment-moderated-flag">({% trans "moderated" %})</span>{% endif %}
               {% if USE_THREADEDCOMMENTS and not preview %}<a href="#c{{ comment.id }}" data-comment-id="{{ comment.id }}" class="comment-reply-link">{% trans "reply" %}</a>{% endif %}
-            </h4>
+          </h4>
 
             <div class="comment-text">{{ comment.comment|linebreaks }}</div>
+        {% endblock %}
         </div>

--- a/fluent_comments/templates/comments/form.html
+++ b/fluent_comments/templates/comments/form.html
@@ -6,7 +6,7 @@
     <form id="comment-form-{{ form.target_object.pk }}" data-object-id="{{ form.target_object.pk }}" action="{% comment_form_target %}" method="post" class="{{ form.helper.form_class|default:'js-comments-form comments-form form-horizontal' }}"
           data-ajax-action="{% url 'comments-post-comment-ajax' %}">
       {% if next %}<div><input type="hidden" name="next" value="{{ next }}" /></div>{% endif %}
-
+      {% block fluent_form %}
       {% crispy form %}
 
       <div class="form-group">
@@ -16,5 +16,6 @@
           {% ajax_comment_tags for form.target_object %}
         </div>
       </div>
+      {% endblock %}
     </form>
 {% endif %}


### PR DESCRIPTION
Now apps can extend the comment and form html used by `fluent_comments`. 

For example, in some hypothetical Django project where we have `fluent_comments` installed, we can have the following setup:

```
/project
  /app
    /templates
      /comments
        comment.html
```

 Then, in `comment.html`

```
{% extends 'comments/comment.html' %}
{% block fluent_comment %}
{{ block.super }}
<-- New HTML here -->
{% endblock %}
```

