### PR TITLE
Change to allow the comment form to appear direclty below the comment being replied to with threaded comments

### DIFF
--- a/fluent_comments/static/fluent_comments/js/ajaxcomments.js
+++ b/fluent_comments/static/fluent_comments/js/ajaxcomments.js
@@ -160,7 +160,7 @@
 
         var $a = $(this);
         var comment_id = $a.attr('data-comment-id');
-        var $comment = $a.closest('.comment-wrapper');
+        var $comment = $a.closest('.comment-item');
 
         removeThreadedPreview();
         $('.js-comments-form').appendTo($comment);


### PR DESCRIPTION
… being replied to when using threaded comments. Currently with threaded comments the form will appear below all the comments associated with the parent comment.