### PR TITLE
Changed user.is_superuser to property from method call

### DIFF
--- a/fluent_comments/moderation.py
+++ b/fluent_comments/moderation.py
@@ -127,7 +127,7 @@ class FluentCommentsModerator(CommentModerator):
             'user_ip': comment.ip_address,
         }
 
-        if comment.user_id and comment.user.is_superuser():
+        if comment.user_id and comment.user.is_superuser:
             data['user_role'] = 'administrator'  # always passes test
 
         # If the language is known, provide it.


### PR DESCRIPTION
Django lists is_superuser as a property, not a method of a user object. See https://docs.djangoproject.com/en/1.10/ref/contrib/auth/

Addresses issue #90.