### PR TITLE
staticfiles template tags is removed in Django 3

### DIFF
--- a/fluent_comments/templates/fluent_comments/templatetags/ajax_comment_tags.html
+++ b/fluent_comments/templates/fluent_comments/templatetags/ajax_comment_tags.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles %}
+{% load i18n static %}
 <a href="#c0" class="comment-cancel-reply-link">{% trans "cancel reply" %}</a>
 <span class="comment-waiting" id="comment-waiting-{{ target_object.pk }}" style="display: none;">
   <img src="{% static 'fluent_comments/img/ajax-wait.gif' %}" alt="" class="ajax-loader" />{% trans "Please wait . . ." %}


### PR DESCRIPTION
For reference: https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0