### PR TITLE
changed loading 'staticfiles' tag library to 'static' library

### DIFF
--- a/fluent_comments/templates/fluent_comments/templatetags/ajax_comment_tags.html
+++ b/fluent_comments/templates/fluent_comments/templatetags/ajax_comment_tags.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles %}
+{% load i18n static %}
 <a href="#c0" class="comment-cancel-reply-link">{% trans "cancel reply" %}</a>
 <span class="comment-waiting" id="comment-waiting-{{ target_object.pk }}" style="display: none;">
   <img src="{% static 'fluent_comments/img/ajax-wait.gif' %}" alt="" class="ajax-loader" />{% trans "Please wait . . ." %}


### PR DESCRIPTION
The 'staticfiles' template tag library was deprecated in Django 2.1 and removed in Django 3.0 in favour of the 'static' templatetag library. This patch should impact almost nothing and re-instates compatiblity with Django 3.0

https://docs.djangoproject.com/en/3.0/releases/2.1/#features-deprecated-in-2-1